### PR TITLE
added Windows 10 as a supported operating system to all manifest files

### DIFF
--- a/Documentation/Content/Uac.aml
+++ b/Documentation/Content/Uac.aml
@@ -34,36 +34,7 @@
     <section address="defaultmanifest">
       <content>
         The following default manifest is embedded with the setup bootstrapper.
-        <code language="xml">
-          <![CDATA[
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
-    <security>
-      <requestedPrivileges>
-        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
-      </requestedPrivileges>
-    </security>
-  </trustInfo>
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
-    <application>
-      <!-- Windows Vista -->
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-    </application>
-  </compatibility>
-  <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="dotNetInstaller" type="win32" />
-  <description>dotNetInstaller</description>
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0"
-       processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" />
-    </dependentAssembly>
-  </dependency>
-</assembly>
-          ]]>
-        </code>
+        <code language="xml" source="..\dotNetInstaller\dotNetInstaller.exe.manifest" />
       </content>
     </section>
   </developerConceptualDocument>

--- a/InstallerDocLib/InstallerDocLib.exe.manifest
+++ b/InstallerDocLib/InstallerDocLib.exe.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
 </assembly>

--- a/InstallerEditor/InstallerEditor.exe.Debug.manifest
+++ b/InstallerEditor/InstallerEditor.exe.Debug.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <dependency>

--- a/InstallerEditor/InstallerEditor.exe.Release.manifest
+++ b/InstallerEditor/InstallerEditor.exe.Release.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <dependency>

--- a/InstallerLinker/InstallerLinker.exe.Debug.manifest
+++ b/InstallerLinker/InstallerLinker.exe.Debug.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <dependency>

--- a/InstallerLinker/InstallerLinker.exe.Release.manifest
+++ b/InstallerLinker/InstallerLinker.exe.Release.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <dependency>

--- a/UnitTests/InstallerEditorUnitTests/UIConfigurationUnitTests.cs
+++ b/UnitTests/InstallerEditorUnitTests/UIConfigurationUnitTests.cs
@@ -321,8 +321,7 @@ namespace InstallerEditorUnitTests
                     {
                         if ((p.MainWindowTitle.StartsWith(windowText)) && (p.MainModule.ModuleName == moduleName))
                         {
-                            Application notepad = Application.Attach(p);
-                            notepad.GetWindow(p.MainWindowTitle, InitializeOption.NoCache).Close();
+                            p.CloseMainWindow();
                             foundNotepad = true;
                             break;
                         }

--- a/dotNetInstaller/dotNetInstaller.exe.manifest
+++ b/dotNetInstaller/dotNetInstaller.exe.manifest
@@ -17,6 +17,8 @@
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="dotNetInstaller" type="win32" />

--- a/htmlInstaller/htmlInstaller.exe.manifest
+++ b/htmlInstaller/htmlInstaller.exe.manifest
@@ -9,14 +9,16 @@
   </trustInfo>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!-- Windows Vista -->
+      <!-- Windows Vista / Windows Server 2008 -->
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-      <!-- Windows 7 -->
+      <!-- Windows 7 / Windows Server 2008 R2 -->
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!-- Windows 8 -->
+      <!-- Windows 8 / Windows Server 2012 -->
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!-- Windows 8.1 -->
+      <!-- Windows 8.1 / Windows Server 2012 R2 -->
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 10 (win10) -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>
   </compatibility>
   <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="htmlInstaller" type="win32" />


### PR DESCRIPTION
removed duplicate code in the "Embedding a Manifest" help topic and injecting manifest XML code directly from the source
fixed failing TestEditWithNotepad unit test