### PR TITLE
 merged latest Third Party Cab and CabLib source code from codeprojec…

### DIFF
--- a/ThirdParty/Cab/Cabinet/Blowfish.hpp
+++ b/ThirdParty/Cab/Cabinet/Blowfish.hpp
@@ -171,7 +171,7 @@ namespace Cabinet
 
                     EncryptBlock(&mu64_Block);
 
-                    memcpy(u8_Crypt, &mu64_Block, 8);
+                    memmove(u8_Crypt, &mu64_Block, 8);
 
                     u8_Crypt      += 8;
                     *pu32_Written += 8;
@@ -384,8 +384,8 @@ namespace Cabinet
                 0x90d4f869, 0xa65cdea0, 0x3f09252d, 0xc208e69f, 0xb74e6132, 0xce77e25b, 0x578fdfe3, 0x3ac372e6
             };
 
-            memcpy(PArr, PArr_Init, sizeof(PArr));
-            memcpy(SBox, SBox_Init, sizeof(SBox));
+            memmove(PArr, PArr_Init, sizeof(PArr));
+            memmove(SBox, SBox_Init, sizeof(SBox));
         }
 
 

--- a/ThirdParty/Cab/Cabinet/Cache.hpp
+++ b/ThirdParty/Cab/Cabinet/Cache.hpp
@@ -129,7 +129,7 @@ namespace Cabinet
             CTrace::TraceW(L"  CMemBlock %s:  Copy Buf RelPos= %05d, Count= %05d", mu16_Name, s32_RelPos, s32_Count);
 #endif
 
-            memcpy(p_Buffer, mu8_Memory + s32_RelPos, s32_Count);
+            memmove(p_Buffer, mu8_Memory + s32_RelPos, s32_Count);
             return s32_Count;
         }
     };

--- a/ThirdParty/Cab/Cabinet/Compress.hpp
+++ b/ThirdParty/Cab/Cabinet/Compress.hpp
@@ -452,15 +452,29 @@ namespace Cabinet
             HANDLE h_File = FindFirstFileW(sw_Path, &k_Find);
 
             if (h_File == INVALID_HANDLE_VALUE)
-                return (GetLastError() == ERROR_FILE_NOT_FOUND);
+            {
+                DWORD u32_Err = GetLastError();
+                if (u32_Err == ERROR_FILE_NOT_FOUND)
+                    return TRUE; // The folder is empty
 
+                mi_Error.Set(0, u32_Err, 0);
+                return FALSE;
+            }
+
+            CStrW sw_File;
             do
             {
-                if (k_Find.cFileName[0] == '.') // directories "." and ".."
+                // skip directories "." and ".." but do not skip a diretory ".NET"
+                if (k_Find.cFileName[0] == '.' && 
+                    k_Find.cFileName[1] == 0)
                     continue;
 
-                CStrW sw_File = sw_Path;
+                if (k_Find.cFileName[0] == '.' && 
+                    k_Find.cFileName[1] == '.' && 
+                    k_Find.cFileName[2] == 0)
+                    continue;
 
+                sw_File = sw_Path;
                 sw_File[s32_Len] = 0;
                 sw_File += k_Find.cFileName;
 

--- a/ThirdParty/Cab/Cabinet/Extract.hpp
+++ b/ThirdParty/Cab/Cabinet/Extract.hpp
@@ -683,7 +683,7 @@ namespace Cabinet
                 // Decrypt data blocks of 8 Bytes
                 mi_Blowfish.CryptBlocks(FALSE, mu8_CryptBuf+s32_UnEncrypted, (s32_Count-s32_UnEncrypted)/8);
 
-                memcpy(memory, mu8_CryptBuf+s32_Offset, count);
+                memmove(memory, mu8_CryptBuf+s32_Offset, count);
 
                 // move filepointer to where Cabinet.dll expects it to be
                 Seek(fd, s32_CabPtr + count, SEEK_SET);

--- a/ThirdParty/Cab/Cabinet/ExtractResource.hpp
+++ b/ThirdParty/Cab/Cabinet/ExtractResource.hpp
@@ -186,7 +186,7 @@ namespace Cabinet
             count = min((long)count, pk_Mem->s32_Size - pk_Mem->s32_Pos);
 
             // Copy the memory in the buffer
-            memcpy(buffer, (char*)(pk_Mem->p_Addr) + pk_Mem->s32_Pos, count);
+            memmove(buffer, (char*)(pk_Mem->p_Addr) + pk_Mem->s32_Pos, count);
 
             // Return the amount of bytes copied
             return count;

--- a/ThirdParty/Cab/Cabinet/Internet.hpp
+++ b/ThirdParty/Cab/Cabinet/Internet.hpp
@@ -160,6 +160,9 @@ namespace Cabinet
         // Server Port (Defaults HTTP:80, FTP:21, HTTPS:443, SOCKS:1080) 
         WORD  mu16_Port;
 
+        // INTERNET_SCHEME_HTTP(S) or INTERNET_SCHEME_FTP
+        DWORD mu32_Scheme;
+
         // INTERNET_SERVICE_HTTP or INTERNET_SERVICE_FTP
         DWORD mu32_Service;
 
@@ -254,8 +257,9 @@ namespace Cabinet
                 return GetInetError();
 
             mu16_Port = k_Comp.nPort;
+            mu32_Scheme = k_Comp.nScheme;
 
-            switch (k_Comp.nScheme)
+            switch (mu32_Scheme)
             {
             case INTERNET_SCHEME_FTP:   mu32_Service = INTERNET_SERVICE_FTP;  break;
             case INTERNET_SCHEME_HTTP:  mu32_Service = INTERNET_SERVICE_HTTP; break;
@@ -376,7 +380,7 @@ namespace Cabinet
             if (!mh_Connection)
                 return GetInetError();
 
-            if (ms_ProxyUser.Len() && ms_ProxyPass.Len())
+            if (ms_ProxyServer.Len() && ms_ProxyUser.Len() && ms_ProxyPass.Len())
             {
                 if (!WI().mf_SetOptionW(mh_Connection, INTERNET_OPTION_PROXY_USERNAME, ms_ProxyUser, ms_ProxyUser.Len()) ||
                     !WI().mf_SetOptionW(mh_Connection, INTERNET_OPTION_PROXY_PASSWORD, ms_ProxyPass, ms_ProxyPass.Len()))
@@ -414,6 +418,15 @@ namespace Cabinet
             // Required for Proxies that use AutoConfig! 
             // See http://msdn.microsoft.com/en-us/library/aa384220(VS.85).aspx
             mu32_ReqFlags |= INTERNET_FLAG_KEEP_CONNECTION; 
+
+            if (mu32_Scheme == INTERNET_SCHEME_HTTPS)
+            {
+                mu32_ReqFlags |= INTERNET_FLAG_SECURE; 
+
+                // Enable the following lines if you want to ignore invalid SSL cerificate host names or expired certificates
+                // mu32_ReqFlags |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID; 
+                // mu32_ReqFlags |= INTERNET_FLAG_IGNORE_CERT_DATE_INVALID; 
+            }
 
             mh_InetFile = WI().mf_HttpOpenRequestW(mh_Connection, u16_Method, s_Url, L"HTTP/1.1", 0, 0, mu32_ReqFlags, 0);
             if (!mh_InetFile)

--- a/ThirdParty/Cab/Cabinet/Map.hpp
+++ b/ThirdParty/Cab/Cabinet/Map.hpp
@@ -106,8 +106,8 @@ namespace Cabinet
                     cDataType* p_DataNew = new cDataType[ms32_Size];
                     if (!p_KeysNew || !p_DataNew) throw "Fatal error: Out of memory!"; // Required for older Visual Studio versions
 
-                    memcpy(p_KeysNew, mp_Keys, ms32_Count * sizeof(cKeyType));
-                    memcpy(p_DataNew, mp_Data, ms32_Count * sizeof(cDataType));
+                    memmove(p_KeysNew, mp_Keys, ms32_Count * sizeof(cKeyType));
+                    memmove(p_DataNew, mp_Data, ms32_Count * sizeof(cDataType));
 
                     delete mp_Keys;
                     delete mp_Data;

--- a/ThirdParty/Cab/Cabinet/String.hpp
+++ b/ThirdParty/Cab/Cabinet/String.hpp
@@ -499,6 +499,7 @@ namespace Cabinet
         {
             if (mu8_Mem) delete[] mu8_Mem;
             mu8_Mem = 0;
+            ms32_Size = 0;
         }
 
         void Allocate(int s32_Size)
@@ -533,7 +534,7 @@ namespace Cabinet
             if (ms32_Len + s32_Len > ms32_Size)
                 return FALSE;
 
-            memcpy(mu8_Mem + ms32_Len, u8_Data, s32_Len);
+            memmove(mu8_Mem + ms32_Len, u8_Data, s32_Len);
             ms32_Len += s32_Len;
             return TRUE;
         }

--- a/ThirdParty/CabLib/Cabinet/Blowfish.hpp
+++ b/ThirdParty/CabLib/Cabinet/Blowfish.hpp
@@ -171,7 +171,7 @@ namespace Cabinet
 
                     EncryptBlock(&mu64_Block);
 
-                    memcpy(u8_Crypt, &mu64_Block, 8);
+                    memmove(u8_Crypt, &mu64_Block, 8);
 
                     u8_Crypt      += 8;
                     *pu32_Written += 8;
@@ -384,8 +384,8 @@ namespace Cabinet
                 0x90d4f869, 0xa65cdea0, 0x3f09252d, 0xc208e69f, 0xb74e6132, 0xce77e25b, 0x578fdfe3, 0x3ac372e6
             };
 
-            memcpy(PArr, PArr_Init, sizeof(PArr));
-            memcpy(SBox, SBox_Init, sizeof(SBox));
+            memmove(PArr, PArr_Init, sizeof(PArr));
+            memmove(SBox, SBox_Init, sizeof(SBox));
         }
 
 

--- a/ThirdParty/CabLib/Cabinet/Cache.hpp
+++ b/ThirdParty/CabLib/Cabinet/Cache.hpp
@@ -129,7 +129,7 @@ namespace Cabinet
             CTrace::TraceW(L"  CMemBlock %s:  Copy Buf RelPos= %05d, Count= %05d", mu16_Name, s32_RelPos, s32_Count);
 #endif
 
-            memcpy(p_Buffer, mu8_Memory + s32_RelPos, s32_Count);
+            memmove(p_Buffer, mu8_Memory + s32_RelPos, s32_Count);
             return s32_Count;
         }
     };

--- a/ThirdParty/CabLib/Cabinet/Compress.hpp
+++ b/ThirdParty/CabLib/Cabinet/Compress.hpp
@@ -452,15 +452,29 @@ namespace Cabinet
             HANDLE h_File = FindFirstFileW(sw_Path, &k_Find);
 
             if (h_File == INVALID_HANDLE_VALUE)
-                return (GetLastError() == ERROR_FILE_NOT_FOUND);
+            {
+                DWORD u32_Err = GetLastError();
+                if (u32_Err == ERROR_FILE_NOT_FOUND)
+                    return TRUE; // The folder is empty
 
+                mi_Error.Set(0, u32_Err, 0);
+                return FALSE;
+            }
+
+            CStrW sw_File;
             do
             {
-                if (k_Find.cFileName[0] == '.') // directories "." and ".."
+                // skip directories "." and ".." but do not skip a diretory ".NET"
+                if (k_Find.cFileName[0] == '.' && 
+                    k_Find.cFileName[1] == 0)
                     continue;
 
-                CStrW sw_File = sw_Path;
+                if (k_Find.cFileName[0] == '.' && 
+                    k_Find.cFileName[1] == '.' && 
+                    k_Find.cFileName[2] == 0)
+                    continue;
 
+                sw_File = sw_Path;
                 sw_File[s32_Len] = 0;
                 sw_File += k_Find.cFileName;
 

--- a/ThirdParty/CabLib/Cabinet/Extract.hpp
+++ b/ThirdParty/CabLib/Cabinet/Extract.hpp
@@ -683,7 +683,7 @@ namespace Cabinet
                 // Decrypt data blocks of 8 Bytes
                 mi_Blowfish.CryptBlocks(FALSE, mu8_CryptBuf+s32_UnEncrypted, (s32_Count-s32_UnEncrypted)/8);
 
-                memcpy(memory, mu8_CryptBuf+s32_Offset, count);
+                memmove(memory, mu8_CryptBuf+s32_Offset, count);
 
                 // move filepointer to where Cabinet.dll expects it to be
                 Seek(fd, s32_CabPtr + count, SEEK_SET);

--- a/ThirdParty/CabLib/Cabinet/ExtractResource.hpp
+++ b/ThirdParty/CabLib/Cabinet/ExtractResource.hpp
@@ -186,7 +186,7 @@ namespace Cabinet
             count = min((long)count, pk_Mem->s32_Size - pk_Mem->s32_Pos);
 
             // Copy the memory in the buffer
-            memcpy(buffer, (char*)(pk_Mem->p_Addr) + pk_Mem->s32_Pos, count);
+            memmove(buffer, (char*)(pk_Mem->p_Addr) + pk_Mem->s32_Pos, count);
 
             // Return the amount of bytes copied
             return count;

--- a/ThirdParty/CabLib/Cabinet/Internet.hpp
+++ b/ThirdParty/CabLib/Cabinet/Internet.hpp
@@ -160,6 +160,9 @@ namespace Cabinet
         // Server Port (Defaults HTTP:80, FTP:21, HTTPS:443, SOCKS:1080) 
         WORD  mu16_Port;
 
+        // INTERNET_SCHEME_HTTP(S) or INTERNET_SCHEME_FTP
+        DWORD mu32_Scheme;
+
         // INTERNET_SERVICE_HTTP or INTERNET_SERVICE_FTP
         DWORD mu32_Service;
 
@@ -254,8 +257,9 @@ namespace Cabinet
                 return GetInetError();
 
             mu16_Port = k_Comp.nPort;
+            mu32_Scheme = k_Comp.nScheme;
 
-            switch (k_Comp.nScheme)
+            switch (mu32_Scheme)
             {
             case INTERNET_SCHEME_FTP:   mu32_Service = INTERNET_SERVICE_FTP;  break;
             case INTERNET_SCHEME_HTTP:  mu32_Service = INTERNET_SERVICE_HTTP; break;
@@ -376,7 +380,7 @@ namespace Cabinet
             if (!mh_Connection)
                 return GetInetError();
 
-            if (ms_ProxyUser.Len() && ms_ProxyPass.Len())
+            if (ms_ProxyServer.Len() && ms_ProxyUser.Len() && ms_ProxyPass.Len())
             {
                 if (!WI().mf_SetOptionW(mh_Connection, INTERNET_OPTION_PROXY_USERNAME, ms_ProxyUser, ms_ProxyUser.Len()) ||
                     !WI().mf_SetOptionW(mh_Connection, INTERNET_OPTION_PROXY_PASSWORD, ms_ProxyPass, ms_ProxyPass.Len()))
@@ -414,6 +418,15 @@ namespace Cabinet
             // Required for Proxies that use AutoConfig! 
             // See http://msdn.microsoft.com/en-us/library/aa384220(VS.85).aspx
             mu32_ReqFlags |= INTERNET_FLAG_KEEP_CONNECTION; 
+
+            if (mu32_Scheme == INTERNET_SCHEME_HTTPS)
+            {
+                mu32_ReqFlags |= INTERNET_FLAG_SECURE; 
+
+                // Enable the following lines if you want to ignore invalid SSL cerificate host names or expired certificates
+                // mu32_ReqFlags |= INTERNET_FLAG_IGNORE_CERT_CN_INVALID; 
+                // mu32_ReqFlags |= INTERNET_FLAG_IGNORE_CERT_DATE_INVALID; 
+            }
 
             mh_InetFile = WI().mf_HttpOpenRequestW(mh_Connection, u16_Method, s_Url, L"HTTP/1.1", 0, 0, mu32_ReqFlags, 0);
             if (!mh_InetFile)

--- a/ThirdParty/CabLib/Cabinet/Map.hpp
+++ b/ThirdParty/CabLib/Cabinet/Map.hpp
@@ -106,8 +106,8 @@ namespace Cabinet
                     cDataType* p_DataNew = new cDataType[ms32_Size];
                     if (!p_KeysNew || !p_DataNew) throw "Fatal error: Out of memory!"; // Required for older Visual Studio versions
 
-                    memcpy(p_KeysNew, mp_Keys, ms32_Count * sizeof(cKeyType));
-                    memcpy(p_DataNew, mp_Data, ms32_Count * sizeof(cDataType));
+                    memmove(p_KeysNew, mp_Keys, ms32_Count * sizeof(cKeyType));
+                    memmove(p_DataNew, mp_Data, ms32_Count * sizeof(cDataType));
 
                     delete mp_Keys;
                     delete mp_Data;

--- a/ThirdParty/CabLib/Cabinet/String.hpp
+++ b/ThirdParty/CabLib/Cabinet/String.hpp
@@ -499,6 +499,7 @@ namespace Cabinet
         {
             if (mu8_Mem) delete[] mu8_Mem;
             mu8_Mem = 0;
+            ms32_Size = 0;
         }
 
         void Allocate(int s32_Size)
@@ -533,7 +534,7 @@ namespace Cabinet
             if (ms32_Len + s32_Len > ms32_Size)
                 return FALSE;
 
-            memcpy(mu8_Mem + ms32_Len, u8_Data, s32_Len);
+            memmove(mu8_Mem + ms32_Len, u8_Data, s32_Len);
             ms32_Len += s32_Len;
             return TRUE;
         }


### PR DESCRIPTION
…t, which includes using memmove instead of memcpy, fixed bug when adding empty folders and folders with a period as a prefix, support for HTTPS, and resetting variable values when freeing