### PR TITLE
calling va_end wherever va_start was called

### DIFF
--- a/ThirdParty/Cab/Cabinet/Blowfish.hpp
+++ b/ThirdParty/Cab/Cabinet/Blowfish.hpp
@@ -36,7 +36,7 @@ namespace Cabinet
     {
     public:
 
-        CBlowfish::CBlowfish()
+        CBlowfish()
         {
             mb_PasswordSet = FALSE;
             ms32_BlockPos  = -1;
@@ -51,7 +51,7 @@ namespace Cabinet
         // It is recommended not to pass the password directly to this function!
         // You should derive for example a HASH from the password and use this instead.
         // See http://en.wikipedia.org/wiki/Key_derivation_function
-        BOOL CBlowfish::SetPassword(void* p_Key, DWORD u32_KeyLen)
+        BOOL SetPassword(void* p_Key, DWORD u32_KeyLen)
         {
             mb_PasswordSet = FALSE;
             ms32_BlockPos  = -1;
@@ -98,7 +98,7 @@ namespace Cabinet
             return TRUE;
         }
 
-        BOOL CBlowfish::IsPasswordSet()
+        BOOL IsPasswordSet()
         {
             return mb_PasswordSet;
         }
@@ -107,7 +107,7 @@ namespace Cabinet
         // The output data overwrites input data in the same buffer.
         // Before calling this you must call SetPassword()!!
         // returns FALSE on error.
-        BOOL CBlowfish::CryptBlocks(BOOL     b_Encrypt,    // TRUE -> Encrypt, FALSE -> Decrypt
+        BOOL CryptBlocks(BOOL     b_Encrypt,    // TRUE -> Encrypt, FALSE -> Decrypt
             BYTE*   u8_Buffer,     // Input + Output data buffer
             DWORD  u32_BlockCount) // The number of blocks (8 Bytes each)
         {
@@ -116,7 +116,7 @@ namespace Cabinet
 
             while (u32_BlockCount > 0)
             {
-                Data64* pu64_Block = (Data64*) u8_Buffer;
+                Data64* pu64_Block = reinterpret_cast<Data64*>(u8_Buffer);
 
                 if (b_Encrypt) EncryptBlock(pu64_Block);
                 else           DecryptBlock(pu64_Block);
@@ -129,7 +129,7 @@ namespace Cabinet
 
         // Initializes for sequential stream encryption
         // Before calling this you must call SetPassword()!!
-        BOOL CBlowfish::EncryptStreamOpen()
+        BOOL EncryptStreamOpen()
         {
             if (!mb_PasswordSet)
                 return FALSE;
@@ -147,7 +147,7 @@ namespace Cabinet
         // Before calling this you must call SetPassword() and then EncryptStreamOpen() !!
         // After encrypting the last block you must call EncryptStreamClose() !!
         // returns FALSE on error.
-        BOOL CBlowfish::EncryptStreamData(BYTE*    u8_Data,     // Input data buffer
+        BOOL EncryptStreamData(BYTE*    u8_Data,     // Input data buffer
             DWORD   u32_DataLen,  // Length of input data (in Bytes)
             BYTE*    u8_Crypt,    // Output data buffer
             DWORD   u32_CryptLen, // Length of output buffer
@@ -185,7 +185,7 @@ namespace Cabinet
         // It is possible that the encrypted stream is up to 7 Bytes longer than the origional stream!
         // You must NOT truncate these extra bytes, otherwise you will not be able to decrypt the end of the stream!
         // returns FALSE on error.
-        BOOL CBlowfish::EncryptStreamClose(BYTE*    u8_Crypt,    // Output data buffer
+        BOOL EncryptStreamClose(BYTE*    u8_Crypt,    // Output data buffer
             DWORD   u32_CryptLen, // Length of output buffer
             DWORD* pu32_Written)  // the number of bytes written to output buffer are added up here
         {
@@ -203,7 +203,7 @@ namespace Cabinet
                 return FALSE;
             }
 
-            Data64* pu64_LastBlock = (Data64*) u8_Crypt;
+            Data64* pu64_LastBlock = reinterpret_cast<Data64*>(u8_Crypt);
             pu64_LastBlock->Val    = 0;
 
             // copy all remaining bytes which must still be encrypted
@@ -243,7 +243,7 @@ namespace Cabinet
         DWORD PArr[P_ARRAYS];             // 18-entry P-array
         DWORD SBox[S_BOXES][BOX_ENTRIES]; // 4 * 256-entry S-boxes
 
-        void CBlowfish::Initialize()
+        void Initialize()
         {
             const DWORD PArr_Init[P_ARRAYS] = // 18-entry P-array
             {
@@ -393,7 +393,7 @@ namespace Cabinet
 
 
         // This function is inline (for highest speed)
-        inline void CBlowfish::EncryptBlock(Data64* pu64_Block)
+        inline void EncryptBlock(Data64* pu64_Block)
         {
             Data32 Lo = pu64_Block->Uint[0];
             Data32 Hi = pu64_Block->Uint[1];
@@ -422,7 +422,7 @@ namespace Cabinet
         }
 
         // This function is inline (for highest speed)
-        inline void CBlowfish::DecryptBlock(Data64* pu64_Block)
+        inline void DecryptBlock(Data64* pu64_Block)
         {
             Data32 Lo = pu64_Block->Uint[0];
             Data32 Hi = pu64_Block->Uint[1];

--- a/ThirdParty/Cab/Cabinet/Compress.hpp
+++ b/ThirdParty/Cab/Cabinet/Compress.hpp
@@ -671,37 +671,37 @@ namespace Cabinet
         { operator delete(memblock); }
 
         static INT_PTR FCIOpen(char* s8_File, int oflag, int pmode, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciOpenA(s8_File, oflag, pmode, err); }
+        { return static_cast<CCompress*>(pThis)->FciOpenA(s8_File, oflag, pmode, err); }
 
         static UINT FCIRead(INT_PTR fd, void *memory, UINT count, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciRead(fd, memory, count, err); }
+        { return static_cast<CCompress*>(pThis)->FciRead(fd, memory, count, err); }
 
         static UINT FCIWrite(INT_PTR fd, void *memory, UINT count, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciWrite(fd, memory, count, err); }
+        { return static_cast<CCompress*>(pThis)->FciWrite(fd, memory, count, err); }
 
         static int FCIClose(INT_PTR fd, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciClose(fd, err); }
+        { return static_cast<CCompress*>(pThis)->FciClose(fd, err); }
 
         static long FCISeek(INT_PTR fd, long offset, int seektype, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciSeek(fd, offset, seektype, err); }
+        { return static_cast<CCompress*>(pThis)->FciSeek(fd, offset, seektype, err); }
 
         static int FCIDelete(char *s8_File, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciDelete(s8_File, err); }
+        { return static_cast<CCompress*>(pThis)->FciDelete(s8_File, err); }
 
         static BOOL FCIGetTempFile(char *pszTempName, int cbTempName, void *pThis)
-        { return ((CCompress*)pThis)->FciGetTempFile(pszTempName, cbTempName); }
+        { return static_cast<CCompress*>(pThis)->FciGetTempFile(pszTempName, cbTempName); }
 
         static INT_PTR FCIGetAttribsAndDate(char *pszName, USHORT *pdate, USHORT *ptime, USHORT *pattribs, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciGetAttribsAndDate(pszName, pdate, ptime, pattribs, err); }
+        { return static_cast<CCompress*>(pThis)->FciGetAttribsAndDate(pszName, pdate, ptime, pattribs, err); }
 
         static int FCIFilePlaced(PCCAB pccab, char *s8_File, int s32_FileSize, BOOL fContinuation, void *pThis)
-        { return ((CCompress*)pThis)->FciFilePlaced(pccab, s8_File, s32_FileSize, fContinuation); }
+        { return static_cast<CCompress*>(pThis)->FciFilePlaced(pccab, s8_File, s32_FileSize, fContinuation); }
 
         static BOOL FCIGetNextCabinet(PCCAB pccab, ULONG cbPrevCab, void* pThis)
-        { return ((CCompress*)pThis)->FciGetNextCabinet(pccab, cbPrevCab); }
+        { return static_cast<CCompress*>(pThis)->FciGetNextCabinet(pccab, cbPrevCab); }
 
         static long FCIUpdateStatus(UINT typeStatus, ULONG cb1, ULONG cb2, void *pThis)
-        { return ((CCompress*)pThis)->FciUpdateStatus(typeStatus, cb1, cb2); }
+        { return static_cast<CCompress*>(pThis)->FciUpdateStatus(typeStatus, cb1, cb2); }
 
         // #################### MEMBER FCI CALLBACKS ########################
 

--- a/ThirdParty/Cab/Cabinet/Extract.hpp
+++ b/ThirdParty/Cab/Cabinet/Extract.hpp
@@ -587,7 +587,7 @@ namespace Cabinet
                 if (!TlsSetValue(CStatic::mu32_ExtractTlsIndex, p_This))
                     return NULL;
             }
-            return (CExtract*)TlsGetValue(CStatic::mu32_ExtractTlsIndex);
+            return static_cast<CExtract*>(TlsGetValue(CStatic::mu32_ExtractTlsIndex));
         }
 
     private:

--- a/ThirdParty/Cab/Cabinet/ExtractMemory.hpp
+++ b/ThirdParty/Cab/Cabinet/ExtractMemory.hpp
@@ -78,7 +78,7 @@ namespace Cabinet
         {
             if (mi_Files.IsCabFile(fd))
             {
-                kMemory* pk_Mem = (kMemory*)fd;
+                kMemory* pk_Mem = reinterpret_cast<kMemory*>(fd);
                 int s32_Read = ReadMem(pk_Mem, buffer, count);
                 if (s32_Read > 0) pk_Mem->s32_Pos += s32_Read;
                 return s32_Read;
@@ -92,7 +92,7 @@ namespace Cabinet
         long Seek(INT_PTR fd, long offset, int origin)
         {
             if (mi_Files.IsCabFile(fd))
-                return SeekMem((kMemory*)fd, offset, origin);
+                return SeekMem(reinterpret_cast<kMemory*>(fd), offset, origin);
             else
                 return CExtract::Seek(fd, offset, origin);
         }
@@ -102,7 +102,7 @@ namespace Cabinet
         int Close(INT_PTR fd)
         {
             if (mi_Files.IsCabFile(fd))
-                return CloseMem((kMemory*)fd);
+                return CloseMem(reinterpret_cast<kMemory*>(fd));
             else
                 return CExtract::Close(fd);
         }

--- a/ThirdParty/Cab/Cabinet/String.hpp
+++ b/ThirdParty/Cab/Cabinet/String.hpp
@@ -182,6 +182,7 @@ namespace Cabinet
                 ms8_Buf[0] = 0;
                 Allocate(mu32_Size * 2); // s32_Len = -1 -> Buffer too small, try again
             }
+            va_end(args);
         }
 
         // Copy string content to external buffer
@@ -405,6 +406,7 @@ namespace Cabinet
                 mu16_Buf[0] = 0;
                 Allocate(mu32_Size * 2); // s32_Len = -1 -> Buffer too small, try again
             }
+            va_end(args);
         }
 
         // Copy string content to external buffer 

--- a/ThirdParty/CabLib/Cabinet/Blowfish.hpp
+++ b/ThirdParty/CabLib/Cabinet/Blowfish.hpp
@@ -36,7 +36,7 @@ namespace Cabinet
     {
     public:
 
-        CBlowfish::CBlowfish()
+        CBlowfish()
         {
             mb_PasswordSet = FALSE;
             ms32_BlockPos  = -1;
@@ -51,7 +51,7 @@ namespace Cabinet
         // It is recommended not to pass the password directly to this function!
         // You should derive for example a HASH from the password and use this instead.
         // See http://en.wikipedia.org/wiki/Key_derivation_function
-        BOOL CBlowfish::SetPassword(void* p_Key, DWORD u32_KeyLen)
+        BOOL SetPassword(void* p_Key, DWORD u32_KeyLen)
         {
             mb_PasswordSet = FALSE;
             ms32_BlockPos  = -1;
@@ -98,7 +98,7 @@ namespace Cabinet
             return TRUE;
         }
 
-        BOOL CBlowfish::IsPasswordSet()
+        BOOL IsPasswordSet()
         {
             return mb_PasswordSet;
         }
@@ -107,7 +107,7 @@ namespace Cabinet
         // The output data overwrites input data in the same buffer.
         // Before calling this you must call SetPassword()!!
         // returns FALSE on error.
-        BOOL CBlowfish::CryptBlocks(BOOL     b_Encrypt,    // TRUE -> Encrypt, FALSE -> Decrypt
+        BOOL CryptBlocks(BOOL     b_Encrypt,    // TRUE -> Encrypt, FALSE -> Decrypt
             BYTE*   u8_Buffer,     // Input + Output data buffer
             DWORD  u32_BlockCount) // The number of blocks (8 Bytes each)
         {
@@ -116,7 +116,7 @@ namespace Cabinet
 
             while (u32_BlockCount > 0)
             {
-                Data64* pu64_Block = (Data64*) u8_Buffer;
+                Data64* pu64_Block = reinterpret_cast<Data64*>(u8_Buffer);
 
                 if (b_Encrypt) EncryptBlock(pu64_Block);
                 else           DecryptBlock(pu64_Block);
@@ -129,7 +129,7 @@ namespace Cabinet
 
         // Initializes for sequential stream encryption
         // Before calling this you must call SetPassword()!!
-        BOOL CBlowfish::EncryptStreamOpen()
+        BOOL EncryptStreamOpen()
         {
             if (!mb_PasswordSet)
                 return FALSE;
@@ -147,7 +147,7 @@ namespace Cabinet
         // Before calling this you must call SetPassword() and then EncryptStreamOpen() !!
         // After encrypting the last block you must call EncryptStreamClose() !!
         // returns FALSE on error.
-        BOOL CBlowfish::EncryptStreamData(BYTE*    u8_Data,     // Input data buffer
+        BOOL EncryptStreamData(BYTE*    u8_Data,     // Input data buffer
             DWORD   u32_DataLen,  // Length of input data (in Bytes)
             BYTE*    u8_Crypt,    // Output data buffer
             DWORD   u32_CryptLen, // Length of output buffer
@@ -185,7 +185,7 @@ namespace Cabinet
         // It is possible that the encrypted stream is up to 7 Bytes longer than the origional stream!
         // You must NOT truncate these extra bytes, otherwise you will not be able to decrypt the end of the stream!
         // returns FALSE on error.
-        BOOL CBlowfish::EncryptStreamClose(BYTE*    u8_Crypt,    // Output data buffer
+        BOOL EncryptStreamClose(BYTE*    u8_Crypt,    // Output data buffer
             DWORD   u32_CryptLen, // Length of output buffer
             DWORD* pu32_Written)  // the number of bytes written to output buffer are added up here
         {
@@ -203,7 +203,7 @@ namespace Cabinet
                 return FALSE;
             }
 
-            Data64* pu64_LastBlock = (Data64*) u8_Crypt;
+            Data64* pu64_LastBlock = reinterpret_cast<Data64*>(u8_Crypt);
             pu64_LastBlock->Val    = 0;
 
             // copy all remaining bytes which must still be encrypted
@@ -243,7 +243,7 @@ namespace Cabinet
         DWORD PArr[P_ARRAYS];             // 18-entry P-array
         DWORD SBox[S_BOXES][BOX_ENTRIES]; // 4 * 256-entry S-boxes
 
-        void CBlowfish::Initialize()
+        void Initialize()
         {
             const DWORD PArr_Init[P_ARRAYS] = // 18-entry P-array
             {
@@ -393,7 +393,7 @@ namespace Cabinet
 
 
         // This function is inline (for highest speed)
-        inline void CBlowfish::EncryptBlock(Data64* pu64_Block)
+        inline void EncryptBlock(Data64* pu64_Block)
         {
             Data32 Lo = pu64_Block->Uint[0];
             Data32 Hi = pu64_Block->Uint[1];
@@ -422,7 +422,7 @@ namespace Cabinet
         }
 
         // This function is inline (for highest speed)
-        inline void CBlowfish::DecryptBlock(Data64* pu64_Block)
+        inline void DecryptBlock(Data64* pu64_Block)
         {
             Data32 Lo = pu64_Block->Uint[0];
             Data32 Hi = pu64_Block->Uint[1];

--- a/ThirdParty/CabLib/Cabinet/Compress.hpp
+++ b/ThirdParty/CabLib/Cabinet/Compress.hpp
@@ -671,37 +671,37 @@ namespace Cabinet
         { operator delete(memblock); }
 
         static INT_PTR FCIOpen(char* s8_File, int oflag, int pmode, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciOpenA(s8_File, oflag, pmode, err); }
+        { return static_cast<CCompress*>(pThis)->FciOpenA(s8_File, oflag, pmode, err); }
 
         static UINT FCIRead(INT_PTR fd, void *memory, UINT count, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciRead(fd, memory, count, err); }
+        { return static_cast<CCompress*>(pThis)->FciRead(fd, memory, count, err); }
 
         static UINT FCIWrite(INT_PTR fd, void *memory, UINT count, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciWrite(fd, memory, count, err); }
+        { return static_cast<CCompress*>(pThis)->FciWrite(fd, memory, count, err); }
 
         static int FCIClose(INT_PTR fd, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciClose(fd, err); }
+        { return static_cast<CCompress*>(pThis)->FciClose(fd, err); }
 
         static long FCISeek(INT_PTR fd, long offset, int seektype, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciSeek(fd, offset, seektype, err); }
+        { return static_cast<CCompress*>(pThis)->FciSeek(fd, offset, seektype, err); }
 
         static int FCIDelete(char *s8_File, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciDelete(s8_File, err); }
+        { return static_cast<CCompress*>(pThis)->FciDelete(s8_File, err); }
 
         static BOOL FCIGetTempFile(char *pszTempName, int cbTempName, void *pThis)
-        { return ((CCompress*)pThis)->FciGetTempFile(pszTempName, cbTempName); }
+        { return static_cast<CCompress*>(pThis)->FciGetTempFile(pszTempName, cbTempName); }
 
         static INT_PTR FCIGetAttribsAndDate(char *pszName, USHORT *pdate, USHORT *ptime, USHORT *pattribs, int *err, void *pThis)
-        { return ((CCompress*)pThis)->FciGetAttribsAndDate(pszName, pdate, ptime, pattribs, err); }
+        { return static_cast<CCompress*>(pThis)->FciGetAttribsAndDate(pszName, pdate, ptime, pattribs, err); }
 
         static int FCIFilePlaced(PCCAB pccab, char *s8_File, int s32_FileSize, BOOL fContinuation, void *pThis)
-        { return ((CCompress*)pThis)->FciFilePlaced(pccab, s8_File, s32_FileSize, fContinuation); }
+        { return static_cast<CCompress*>(pThis)->FciFilePlaced(pccab, s8_File, s32_FileSize, fContinuation); }
 
         static BOOL FCIGetNextCabinet(PCCAB pccab, ULONG cbPrevCab, void* pThis)
-        { return ((CCompress*)pThis)->FciGetNextCabinet(pccab, cbPrevCab); }
+        { return static_cast<CCompress*>(pThis)->FciGetNextCabinet(pccab, cbPrevCab); }
 
         static long FCIUpdateStatus(UINT typeStatus, ULONG cb1, ULONG cb2, void *pThis)
-        { return ((CCompress*)pThis)->FciUpdateStatus(typeStatus, cb1, cb2); }
+        { return static_cast<CCompress*>(pThis)->FciUpdateStatus(typeStatus, cb1, cb2); }
 
         // #################### MEMBER FCI CALLBACKS ########################
 

--- a/ThirdParty/CabLib/Cabinet/Extract.hpp
+++ b/ThirdParty/CabLib/Cabinet/Extract.hpp
@@ -587,7 +587,7 @@ namespace Cabinet
                 if (!TlsSetValue(CStatic::mu32_ExtractTlsIndex, p_This))
                     return NULL;
             }
-            return (CExtract*)TlsGetValue(CStatic::mu32_ExtractTlsIndex);
+            return static_cast<CExtract*>(TlsGetValue(CStatic::mu32_ExtractTlsIndex));
         }
 
     private:

--- a/ThirdParty/CabLib/Cabinet/ExtractMemory.hpp
+++ b/ThirdParty/CabLib/Cabinet/ExtractMemory.hpp
@@ -78,7 +78,7 @@ namespace Cabinet
         {
             if (mi_Files.IsCabFile(fd))
             {
-                kMemory* pk_Mem = (kMemory*)fd;
+                kMemory* pk_Mem = reinterpret_cast<kMemory*>(fd);
                 int s32_Read = ReadMem(pk_Mem, buffer, count);
                 if (s32_Read > 0) pk_Mem->s32_Pos += s32_Read;
                 return s32_Read;
@@ -92,7 +92,7 @@ namespace Cabinet
         long Seek(INT_PTR fd, long offset, int origin)
         {
             if (mi_Files.IsCabFile(fd))
-                return SeekMem((kMemory*)fd, offset, origin);
+                return SeekMem(reinterpret_cast<kMemory*>(fd), offset, origin);
             else
                 return CExtract::Seek(fd, offset, origin);
         }
@@ -102,7 +102,7 @@ namespace Cabinet
         int Close(INT_PTR fd)
         {
             if (mi_Files.IsCabFile(fd))
-                return CloseMem((kMemory*)fd);
+                return CloseMem(reinterpret_cast<kMemory*>(fd));
             else
                 return CExtract::Close(fd);
         }

--- a/ThirdParty/CabLib/Cabinet/ExtractUrl.hpp
+++ b/ThirdParty/CabLib/Cabinet/ExtractUrl.hpp
@@ -294,7 +294,7 @@ namespace Cabinet
         // This function is called from the cache to read the next data block from the server into memory
         static int CacheCallback(void* p_Buffer, DWORD u32_Offset, DWORD u32_Count)
         {
-            CExtractUrl* p_This = (CExtractUrl*)This();
+            CExtractUrl* p_This = static_cast<CExtractUrl*>(This());
 
             DWORD u32_Read, u32_ApiErr, u32_Status;
             if (u32_ApiErr = p_This->mi_Internet.DownloadFilePartToMemory(p_Buffer, 

--- a/ThirdParty/CabLib/Cabinet/String.hpp
+++ b/ThirdParty/CabLib/Cabinet/String.hpp
@@ -182,6 +182,7 @@ namespace Cabinet
                 ms8_Buf[0] = 0;
                 Allocate(mu32_Size * 2); // s32_Len = -1 -> Buffer too small, try again
             }
+            va_end(args);
         }
 
         // Copy string content to external buffer
@@ -405,6 +406,7 @@ namespace Cabinet
                 mu16_Buf[0] = 0;
                 Allocate(mu32_Size * 2); // s32_Len = -1 -> Buffer too small, try again
             }
+            va_end(args);
         }
 
         // Copy string content to external buffer 

--- a/ThirdParty/CabLib/LibCompress.cpp
+++ b/ThirdParty/CabLib/LibCompress.cpp
@@ -314,7 +314,7 @@ _Exit:
             VariantClear(pk_Args + i); // free BSTR if required
         }
 
-        delete pk_Args;
+        delete[] pk_Args;
         Marshal::FreeHGlobal(u16_Format);
 
         return new String(s_String);
@@ -382,7 +382,7 @@ _Exit:
         if (!p_Param) // May happen if destructor of CCompress calls DestroyFciContext()
             return 0;
 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
 
         // With this event you can display the progress of compression in your GUI
         if (!p_Bridge->mev_UpdateStatus) 
@@ -409,7 +409,7 @@ _Exit:
         if (!p_Param) // May happen if destructor of CCompress calls DestroyFciContext()
             return 0; 
 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
 
         // With this event you can display in your GUI the file which was added to the CAB
         if (!p_Bridge->mev_FilePlaced) 

--- a/ThirdParty/CabLib/LibCompress.h
+++ b/ThirdParty/CabLib/LibCompress.h
@@ -90,6 +90,7 @@ namespace CabLib
 			// Not even the public events can be accessed from within the callbacks of the bridge class
 			cCallbackBridge(gcroot<delUpdateStatus*> ev_UpdateStatus,
 							gcroot<delFilePlaced*>   ev_FilePlaced)
+                            : mi_Compress(NULL)
 			{
 				mev_UpdateStatus = ev_UpdateStatus;
 				mev_FilePlaced   = ev_FilePlaced;

--- a/ThirdParty/CabLib/LibExtract.cpp
+++ b/ThirdParty/CabLib/LibExtract.cpp
@@ -614,7 +614,7 @@ _Exit:
     // Return TRUE to extract the file or FALSE to skip the file.
     BOOL CabLib::Extract::cCallbackBridge::OnBeforeCopyFile(Cabinet::CExtract::kCabinetFileInfo *pk_Info, void* p_Param)
     { 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
 
         // Extract single file specified by user from the root folder in the CAB file
         if (p_Bridge->ms_SingleFile && p_Bridge->ms_SingleFile->Length)
@@ -649,7 +649,7 @@ _Exit:
     // If ExtractToMemory is not enabled, u8_ExtractMem is null
     void CabLib::Extract::cCallbackBridge::OnAfterCopyFile(WCHAR* u16_File, Cabinet::CMemory* pi_ExtractMem, void* p_Param)
     { 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         if (!p_Bridge->mev_AfterCopyFile)
             return;
 
@@ -668,7 +668,7 @@ _Exit:
 
     void CabLib::Extract::cCallbackBridge::OnProgressInfo(Cabinet::CExtract::kProgressInfo* pk_Info, void* p_Param)
     { 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         if (!p_Bridge->mev_ProgressInfo)
             return;
 
@@ -688,7 +688,7 @@ _Exit:
     // including continuation cabinets opened due to files which are spanning over cabinet boundaries. 
     void CabLib::Extract::cCallbackBridge::OnCabinetInfo(Cabinet::CExtract::kCabinetInfo* pk_Info, void* p_Param)
     {
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         if (!p_Bridge->mev_CabinetInfo) 
             return;
 
@@ -710,7 +710,7 @@ _Exit:
     // with the second parameter set to an error that describes the problem.
     void CabLib::Extract::cCallbackBridge::OnNextCabinet(Cabinet::CExtract::kCabinetInfo *pk_Info, int s32_FdiError, void* p_Param)
     { 
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         if (!p_Bridge->mev_NextCabinet)
             return;
 
@@ -735,13 +735,13 @@ _Exit:
 
     int CabLib::Extract::cCallbackBridge::OnStreamGetLen(void* p_Param)
     {
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         return (int)p_Bridge->mi_Stream->Length; 
     }
 
     int CabLib::Extract::cCallbackBridge::OnStreamRead(void* p_Buffer, int Pos, UINT u32_Count, void* p_Param)
     {
-        cCallbackBridge* p_Bridge = (cCallbackBridge*)p_Param;
+        cCallbackBridge* p_Bridge = static_cast<cCallbackBridge*>(p_Param);
         p_Bridge->mi_Stream->Position = Pos;
 
         System::Byte u8_ReadBuf[] = new System::Byte[u32_Count];

--- a/build.cmd
+++ b/build.cmd
@@ -7,12 +7,6 @@ if "%~1"=="" (
  goto :EOF
 )
 
-PATH ;%~dp0ThirdParty\Microsoft\Windows SDK v6.0\VC\Bin;%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\bin;%PATH%
-SET VCINSTALLDIR=%~dp0ThirdParty\Microsoft\Windows SDK v6.0\VC
-SET VCBuildToolPath=%~dp0ThirdParty\Microsoft\Windows SDK v6.0\VC\Bin
-SET INCLUDE=%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\include;%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\include;%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Include;%INCLUDE%
-SET LIB=%~dp0\ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Lib;%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\lib;%~dp0ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\lib;%LIB%
-
 %SystemRoot%\Microsoft.NET\Framework\v2.0.50727\msbuild.exe dni.proj /t:%* /l:FileLogger,Microsoft.Build.Engine;logfile="dni_%1.log"
 
 popd

--- a/dni.debug.vsprops
+++ b/dni.debug.vsprops
@@ -8,18 +8,18 @@
 	>
 	<Tool
 		Name="VCCLCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;;$(INCLUDE)"
+		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Include"
 		WarningLevel="4"
 		DebugInformationFormat="4"
 	/>
 	<Tool
 		Name="VCLinkerTool"
 		AdditionalOptions="/nod:kernel32.lib /nod:advapi32.lib /nod:user32.lib /nod:gdi32.lib /nod:shell32.lib /nod:comdlg32.lib /nod:version.lib /nod:mpr.lib /nod:rasapi32.lib /nod:winmm.lib /nod:winspool UnicoWS.lib Kernel32.lib Advapi32.lib User32.lib Gdi32.lib Shell32.lib Comdlg32.lib Version.lib Mpr.lib Rasapi32.lib Winmm.lib Winspool.lib Vfw32.lib Secur32.lib Oleacc.lib Oledlg.lib Sensapi.lib Msi.lib"
-		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;;$(LIB)"
+		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;;$(SolutionDir)\ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Lib;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\lib;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\lib"
 		GenerateDebugInformation="true"
 	/>
 	<Tool
 		Name="VCResourceCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;;$(INCLUDE)"
+		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Include"
 	/>
 </VisualStudioPropertySheet>

--- a/dni.vsprops
+++ b/dni.vsprops
@@ -8,17 +8,17 @@
 	>
 	<Tool
 		Name="VCCLCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;;$(INCLUDE)"
+		AdditionalIncludeDirectories="&quot;$(SolutionDir)&quot;;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Include"
 		WarningLevel="4"
 	/>
 	<Tool
 		Name="VCLinkerTool"
 		AdditionalOptions="/nod:kernel32.lib /nod:advapi32.lib /nod:user32.lib /nod:gdi32.lib /nod:shell32.lib /nod:comdlg32.lib /nod:version.lib /nod:mpr.lib /nod:rasapi32.lib /nod:winmm.lib /nod:winspool UnicoWS.lib Kernel32.lib Advapi32.lib User32.lib Gdi32.lib Shell32.lib Comdlg32.lib Version.lib Mpr.lib Rasapi32.lib Winmm.lib Winspool.lib Vfw32.lib Secur32.lib Oleacc.lib Oledlg.lib Sensapi.lib Msi.lib"
-		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;;$(LIB)"
+		AdditionalLibraryDirectories="&quot;$(SolutionDir)\ThirdParty\Msi\lib&quot;;&quot;$(SolutionDir)\ThirdParty\TinyXml\lib&quot;;$(SolutionDir)\ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Lib;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\lib;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\lib"
 		GenerateDebugInformation="true"
 	/>
 	<Tool
 		Name="VCResourceCompilerTool"
-		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;;$(INCLUDE)"
+		AdditionalIncludeDirectories="&quot;$(IntDir)&quot;;&quot;$(SolutionDir)&quot;;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\atlmfc\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\include;$(SolutionDir)ThirdParty\Microsoft\Visual Studio 8\VC\PlatformSDK\Include"
 	/>
 </VisualStudioPropertySheet>

--- a/dotNetInstaller/BrowseCtrl.cpp
+++ b/dotNetInstaller/BrowseCtrl.cpp
@@ -739,7 +739,7 @@ void CBrowseCtrl::SetPathName(LPCTSTR lpszPathName)
 int CBrowseCtrl::BrowseCallbackProc(HWND hwnd, UINT nMsg, LPARAM lParam, LPARAM lpData)
 {	
     lParam = 0; // Appeases VC6 warning level 4.
-    CBrowseCtrl* pCtrl = (CBrowseCtrl*)(lpData);
+    CBrowseCtrl* pCtrl = reinterpret_cast<CBrowseCtrl*>(lpData);
     if (pCtrl == NULL)
         return 0;
 

--- a/dotNetInstaller/ComponentsList.cpp
+++ b/dotNetInstaller/ComponentsList.cpp
@@ -104,7 +104,7 @@ void CComponentsList::OnLButtonDblClk(UINT nFlags, CPoint point)
         UINT uiItem = ItemFromPoint(point, bOutside);
         if (! bOutside)
         {
-            ComponentPtr component = m_pConfiguration->GetComponentPtr((Component *) GetItemDataPtr(uiItem));
+            ComponentPtr component = m_pConfiguration->GetComponentPtr(static_cast<Component*>(GetItemDataPtr(uiItem)));
             Exec(component);
             if (m_pExecuteCallback)
             {
@@ -118,7 +118,7 @@ void CComponentsList::OnLButtonDblClk(UINT nFlags, CPoint point)
         UINT uiItem = ItemFromPoint(point, bOutside);
         if (! bOutside)
         {
-            ComponentPtr component = m_pConfiguration->GetComponentPtr((Component *) GetItemDataPtr(uiItem));			
+            ComponentPtr component = m_pConfiguration->GetComponentPtr(static_cast<Component*>(GetItemDataPtr(uiItem)));
             SetCheck(uiItem, ! GetCheck(uiItem));
         }
     }

--- a/dotNetInstaller/DownloadDialog.cpp
+++ b/dotNetInstaller/DownloadDialog.cpp
@@ -208,7 +208,6 @@ void CDownloadDialog::Connecting(const std::wstring& host)
 
 void CDownloadDialog::SendingRequest(const std::wstring& host)
 {
-    std::wstring message = DVLib::FormatMessage(const_cast<wchar_t *>(m_MessageConnecting.c_str()), host.c_str());
     DownloadStatusPtr status(DownloadStatus::CreateProgress(m_MessageSendingRequest, 0, 0));
     ::PostMessage(m_hWnd, WM_USER_SETSTATUSDOWNLOAD, (WPARAM)(release(status)), 0L );
 }

--- a/dotNetInstaller/KCBusyProgressCtrl.cpp
+++ b/dotNetInstaller/KCBusyProgressCtrl.cpp
@@ -336,10 +336,10 @@ void CKCBusyProgressCtrl::OnSize(UINT nType, int cx, int cy)
 
 void CKCBusyProgressCtrl::StepIt()
 {
-    int				nNumSteps = 0;
-
     if ( m_nMode & BPC_MODE_BUSY)
     {
+        int nNumSteps = 0;
+
         switch ( m_nBusyFill )
         {
         case	BPC_BUSYFILL_BLOCK:
@@ -438,7 +438,7 @@ void CKCBusyProgressCtrl::End()
 
 UINT CKCBusyProgressCtrl::thrdBusy(LPVOID pParam)
 {
-    CKCBusyProgressCtrl*			pThis = (CKCBusyProgressCtrl*) pParam;
+    CKCBusyProgressCtrl*			pThis = static_cast<CKCBusyProgressCtrl*>(pParam);
 
     if ( !pThis )
         return 0;

--- a/dotNetInstaller/LanguageSelectorDialog.cpp
+++ b/dotNetInstaller/LanguageSelectorDialog.cpp
@@ -5,12 +5,12 @@
 IMPLEMENT_DYNAMIC(CLanguageSelectorDialog, CDialog)
 
 CLanguageSelectorDialog::CLanguageSelectorDialog(const ConfigFile& configfile, CWnd* pParent /*=NULL*/)
-: CDialog(CLanguageSelectorDialog::IDD, pParent)
+: CDialog(CLanguageSelectorDialog::IDD, pParent),
+m_Configurations(configfile),
+m_CancelText(configfile.language_selector_cancel),
+m_OKText(configfile.language_selector_ok),
+m_Title(configfile.language_selector_title)
 {
-    m_Configurations = configfile;
-    m_CancelText = configfile.language_selector_cancel;
-    m_OKText = configfile.language_selector_ok;
-    m_Title = configfile.language_selector_title;
 }
 
 void CLanguageSelectorDialog::DoDataExchange(CDataExchange* pDX)

--- a/dotNetInstaller/dotNetInstaller.cpp
+++ b/dotNetInstaller/dotNetInstaller.cpp
@@ -53,7 +53,7 @@ BOOL CdotNetInstallerApp::InitInstance()
         while(arg != InstallerCommandLineInfo::Instance->componentCmdArgs.end())
         {
             LOG(L"Component arguments: \"" + arg->first + L"\": " << arg->second);
-            arg ++;
+            arg++;
         }
 
         // propagate command line arguments during execution

--- a/dotNetInstaller/dotNetInstallerDlg.cpp
+++ b/dotNetInstaller/dotNetInstallerDlg.cpp
@@ -194,7 +194,7 @@ void CdotNetInstallerDlg::SelectComponents()
 {
     for(int i = 0; i < m_ListBoxComponents.GetCount(); i++)
     {
-        Component * pComponent = (Component *) m_ListBoxComponents.GetItemDataPtr(i);
+        Component * pComponent = static_cast<Component*>(m_ListBoxComponents.GetItemDataPtr(i));
         pComponent->checked = (m_ListBoxComponents.GetCheck(i) == 1);
     }
 }

--- a/dotNetInstallerLib/DownloadDialog.cpp
+++ b/dotNetInstallerLib/DownloadDialog.cpp
@@ -79,7 +79,7 @@ int DownloadDialog::ExecOnThread()
                 callback->DownloadError(DVLib::string2wstring(ex.what()).c_str());
             }
 
-            throw ex;
+            throw;
         }
     }
 

--- a/dotNetInstallerLib/ExeComponent.cpp
+++ b/dotNetInstallerLib/ExeComponent.cpp
@@ -23,7 +23,6 @@ void ExeComponent::Exec()
     std::wstring l_exeparameters;
     std::wstring l_responsefile_source;
     std::wstring l_responsefile_target;
-    std::wstring l_responsefile_processed;
 
     // make executable executable
     switch(InstallerSession::Instance->sequence)

--- a/dotNetInstallerLib/ExtractComponent.cpp
+++ b/dotNetInstallerLib/ExtractComponent.cpp
@@ -83,7 +83,7 @@ BOOL ExtractComponent::OnBeforeCopyFile(Cabinet::CExtract::kCabinetFileInfo * k_
 {
     LOG(L"Extracting: " << k_FI->u16_FullPath);
 
-    ExtractComponent * extractComponent = (ExtractComponent *) p_Param;
+    ExtractComponent * extractComponent = static_cast<ExtractComponent*>(p_Param);
 
     extractComponent->OnStatus(std::wstring(k_FI->u16_File) + L" - " + DVLib::FormatBytesW(k_FI->s32_Size));
 
@@ -131,7 +131,7 @@ std::wstring ExtractComponent::GetResName(int currentIndex) const
 
 void ExtractComponent::OnProgressInfo(Cabinet::CExtract::kProgressInfo* pk_Progress, void* p_Param)
 {
-    ExtractComponent * extractComponent = (ExtractComponent *) p_Param;
+    ExtractComponent * extractComponent = static_cast<ExtractComponent*>(p_Param);
 
     extractComponent->OnStatus(std::wstring(pk_Progress->u16_RelPath) + L" - " + 
         DVLib::FormatMessage(L"%.f%%", pk_Progress->fl_Percent));

--- a/dotNetInstallerLib/InstallerUI.cpp
+++ b/dotNetInstallerLib/InstallerUI.cpp
@@ -728,11 +728,11 @@ void InstallerUI::AddUserControls()
         switch(control->type)
         {
         case control_type_label:
-            AddControl(* (ControlLabel *) get(control));
+            AddControl(* static_cast<ControlLabel*>(get(control)));
             break;
         case control_type_checkbox:
             {
-                ControlCheckBox * control_checkbox = (ControlCheckBox *) get(control);
+                ControlCheckBox * control_checkbox = static_cast<ControlCheckBox*>(get(control));
                 std::map<std::wstring, std::wstring>::iterator value;
                 if ((value = InstallerSession::Instance->AdditionalControlArgs.find(control_checkbox->id)) != 
                     InstallerSession::Instance->AdditionalControlArgs.end())
@@ -757,7 +757,7 @@ void InstallerUI::AddUserControls()
             break;
         case control_type_edit:
             {
-                ControlEdit * control_edit = (ControlEdit *) get(control);
+                ControlEdit * control_edit = static_cast<ControlEdit*>(get(control));
                 std::map<std::wstring, std::wstring>::iterator value;
                 if ((value = InstallerSession::Instance->AdditionalControlArgs.find(control_edit->id)) != 
                     InstallerSession::Instance->AdditionalControlArgs.end())
@@ -770,7 +770,7 @@ void InstallerUI::AddUserControls()
             break;
         case control_type_browse:
             {
-                ControlBrowse * control_browse = (ControlBrowse *) get(control);
+                ControlBrowse * control_browse = static_cast<ControlBrowse*>(get(control));
                 std::map<std::wstring, std::wstring>::iterator value;
                 if ((value = InstallerSession::Instance->AdditionalControlArgs.find(control_browse->id)) != 
                     InstallerSession::Instance->AdditionalControlArgs.end())
@@ -787,7 +787,7 @@ void InstallerUI::AddUserControls()
             break;
         case control_type_license:
             {
-                ControlLicense * control_license = (ControlLicense *) get(control);
+                ControlLicense * control_license = static_cast<ControlLicense*>(get(control));
                 // extract license to temporary location
                 std::vector<char> license_buffer = DVLib::LoadResourceData<char>(NULL, control_license->resource_id, L"CUSTOM");
                 std::wstring license_file = DVLib::DirectoryCombine(DVLib::GetTemporaryDirectoryW(), InstallerSession::Instance->guid + L"_" + DVLib::GetFileNameW(control_license->license_file));
@@ -798,10 +798,10 @@ void InstallerUI::AddUserControls()
             }
             break;
         case control_type_hyperlink:
-            AddControl(* (ControlHyperlink *) get(control));
+            AddControl(* static_cast<ControlHyperlink*>(get(control)));
             break;
         case control_type_image:
-            AddControl(* (ControlImage *) get(control));
+            AddControl(* static_cast<ControlImage*>(get(control)));
             break;
         default:
             THROW_EX(L"Invalid control type: " << control->type);

--- a/dotNetInstallerLib/ThreadComponent.cpp
+++ b/dotNetInstallerLib/ThreadComponent.cpp
@@ -24,7 +24,7 @@ bool ThreadComponent::IsExecuting(DWORD dwTimeout) const
 
 UINT ThreadComponent::ExecuteThread(LPVOID pParam)
 {
-    ThreadComponent * pComponent = (ThreadComponent *) pParam;
+    ThreadComponent * pComponent = static_cast<ThreadComponent*>(pParam);
 
     try
     {

--- a/dotNetInstallerToolsLib/StringUtilImpl.h
+++ b/dotNetInstallerToolsLib/StringUtilImpl.h
@@ -9,10 +9,11 @@ public:
 	{
 		std::basic_string<T> s(s_in);
 		std::basic_string<T>::size_type ii = 0;
-		int result = 0; // \todo: return number of replacements
 		
 		if (s.length() != 0 && from.length() != 0)
 		{
+			int result = 0; // \todo: return number of replacements
+			
 			while ((ii = s.find(from, ii)) != s.npos) 
 			{
 				s.replace(ii, from.length(), to);

--- a/htmlInstaller/HtmlWindow.cpp
+++ b/htmlInstaller/HtmlWindow.cpp
@@ -393,6 +393,6 @@ void HtmlWindow::DoModal(int cmd)
         DniMessageBox::Show(DVLib::string2wstring(ex.what()).c_str(), MB_OK|MB_ICONSTOP);
         m_modal = false;
         ::DestroyWindow(hwnd);
-        throw ex;
+        throw;
     }
 }

--- a/htmlInstaller/InstallerWindow.cpp
+++ b/htmlInstaller/InstallerWindow.cpp
@@ -245,7 +245,7 @@ BOOL InstallerWindow::on_mouse_dclick(HELEMENT /* he */, HELEMENT target,
 
 UINT InstallerWindow::RunComponentOnThread(LPVOID pParam)
 {
-    InstallerWindow * p_window = (InstallerWindow *) pParam;
+    InstallerWindow * p_window = static_cast<InstallerWindow*>(pParam);
 
     try
     {

--- a/htmlInstaller/htmlInstaller.cpp
+++ b/htmlInstaller/htmlInstaller.cpp
@@ -56,7 +56,7 @@ BOOL CHtmlInstallerApp::InitInstance()
         while(arg != InstallerCommandLineInfo::Instance->componentCmdArgs.end())
         {
             LOG(L"Component arguments: \"" + arg->first + L"\": " << arg->second);
-            arg ++;
+            arg++;
         }
 
         // propagate command line arguments during execution


### PR DESCRIPTION
using delete[] instead of delete for VARIANT* created with new VARIANT[]
initialized uninitialized variable
using static_cast and reinterpret_cast instead of C-style pointer casting
using specific paths instead of environment variables for INCLUDE and LIB